### PR TITLE
Unset variable that is leaked because it is 'include()'ed

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.13.0)
 
-push(shacl.cmake.is_subproject)
-
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(shacl.cmake.is_subproject TRUE)
 else()
@@ -35,8 +33,6 @@ if(shacl.cmake.installation STREQUAL "default")
     set(shacl.cmake.install ON)
   endif()
 endif()
-
-pop(shacl.cmake.is_subproject)
 
 include_guard(GLOBAL)
 if(shacl.cmake.installation)

--- a/config.cmake
+++ b/config.cmake
@@ -34,6 +34,7 @@ if(shacl.cmake.installation STREQUAL "default")
   endif()
 endif()
 
+unset(subproject)
 include_guard(GLOBAL)
 if(shacl.cmake.installation)
   install(FILES "${CMAKE_CURRENT_LIST_FILE}"

--- a/config.cmake
+++ b/config.cmake
@@ -1,12 +1,14 @@
 cmake_minimum_required(VERSION 3.13.0)
 
+push(shacl.cmake.is_subproject)
+
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-  set(subproject TRUE)
+  set(shacl.cmake.is_subproject TRUE)
 else()
-  set(subproject FALSE)
+  set(shacl.cmake.is_subproject FALSE)
 endif()
 
-if(subproject)
+if(shacl.cmake.is_subproject)
   if(NOT DEFINED INSTALL_SUBPROJECTS)
     option(INSTALL_SUBPROJECTS
       "Perform full installation of subproject dependencies" ON)
@@ -27,14 +29,15 @@ if(NOT DEFINED shacl.cmake.installation)
 endif()
 
 if(shacl.cmake.installation STREQUAL "default")
-  if(subproject)
+  if(shacl.cmake.is_subproject)
     set(shacl.cmake.install "${INSTALL_SUBPROJECTS}")
   else()
     set(shacl.cmake.install ON)
   endif()
 endif()
 
-unset(subproject)
+pop(shacl.cmake.is_subproject)
+
 include_guard(GLOBAL)
 if(shacl.cmake.installation)
   install(FILES "${CMAKE_CURRENT_LIST_FILE}"


### PR DESCRIPTION
I assume this is a bug? Because it always matches a corresponding value that would be set inside of the consuming project that included it, it more or less behaves OK.   Or is this a standard practice that is maybe not obvious?

Unfortunately, this caused mass confusion because I had goofed and used "is_subproject" and then was later dispatching on "subproject", which happened to work because shacl/.cmake was propagating it upward. It is highly possible the same mistake is elsewhere so I need to dig through all of the shacl projects before merging this (so the next time we update we don't get a silent break).