### PR TITLE
bugfix/check_version

### DIFF
--- a/Git/Submodule/Packages.cmake
+++ b/Git/Submodule/Packages.cmake
@@ -7,6 +7,7 @@ include("Git/Submodule/Packages/init")
 include("Git/Submodule/Packages/update")
 include("Git/Submodule/Packages/package")
 include("Git/Submodule/Packages/find_package")
+include("Git/Submodule/Packages/check_version")
 git_submodule_list()
 
 include_guard(DIRECTORY)

--- a/Git/Submodule/Packages/check_version.cmake
+++ b/Git/Submodule/Packages/check_version.cmake
@@ -1,3 +1,5 @@
+macro(Git_Submodule_Packages_check_version)
+
 get_property(${git.submodule.packages.subject}_VERSION GLOBAL PROPERTY
   ${git.submodule.packages.subject}_VERSION SET)
 
@@ -132,3 +134,5 @@ if(PACKAGE_FIND_VERSION)
   pop(PACKAGE_VERSION_COMPATIBLE)
   pop(PACKAGE_VERSION_EXACT)
 endif()
+
+endmacro()

--- a/Git/Submodule/Packages/find_package.cmake
+++ b/Git/Submodule/Packages/find_package.cmake
@@ -211,7 +211,7 @@ macro(find_package name)
         set(${name}_FOUND TRUE)
       endif()
 
-      include(Git/Submodule/Packages/check_version)
+      Git_Submodule_Packages_check_version()
       pop(git.submodule.package.${name}.traversed)
     endif()
 


### PR DESCRIPTION
Makes check_version a macro to avoid issues with top-level project's CMAKE_MODULE_PATH not including Git/Submodule/Packages.  This issue arose when a dependency using shacl::cmake was brought into a project via FetchContent.