### PR TITLE
Updates shacl_FetchContent 

### DIFF
--- a/shacl_FetchContent.cmake
+++ b/shacl_FetchContent.cmake
@@ -117,6 +117,8 @@ function(shacl_FetchContent_Declare name)
 
   # Option to enable force fetching via configuration
   option(shacl_FetchContent.${name}.override_find_package "Force fetch of ${name} instead of first calling find_package" OFF)
+  # Option to enable force finding of pckages for use in spack installations via configuration
+  option(shacl_FetchContent.force_find_package "Disable fetching of all packages found via shacl_FetchContent by only using find_package instead" OFF)
 
   # copy argument list as methods like list(FIND...) don't work on ${ARGV}
   set (args ${ARGV})
@@ -141,6 +143,7 @@ function(shacl_FetchContent_Declare name)
     # if OVERRIDE_FIND_PACKAGE is not present then add it
     if (${override_pkg_index} EQUAL -1)
       list(APPEND arg_subset OVERRIDE_FIND_PACKAGE)
+      list(FIND arg_subset OVERRIDE_FIND_PACKAGE override_pkg_index)
     endif()
   else() # if not force fetching then call find_package first
     set(arg_subset ${args})
@@ -150,6 +153,12 @@ function(shacl_FetchContent_Declare name)
     endif()
   endif()
 
+  if (shacl_FetchContent.force_find_package)
+    if(NOT override_pkg_index EQUAL -1)
+      message(FATAL_ERROR "shacl_FetchContent - cannot use OVERRIDE_FIND_PACKAGE in conjunction with shacl_Fetchcontent.force_find_package")
+    endif()
+      list(APPEND arg_subset REQUIRED)
+  endif()
   # If the dependency uses a relative path then it uses the same server as the host project.
   # This is useful for automated testing with gitlab CI tokens or if repos are hosted on different servers
   # e.g. if the project is hosted on github then pull all relative dependencies from github.

--- a/shacl_FetchContent/relative_git_url.cmake
+++ b/shacl_FetchContent/relative_git_url.cmake
@@ -27,18 +27,43 @@ endfunction()
 # the url relative to the current project's url
 function(get_dependency_url input_url return_url)   
 
+  if(${CMAKE_VERSION} VERSION_GREATER "3.26")
+    # CMake 3.27 can handle relative URLs, don't do anything
+    cmake_policy(SET CMP0150 NEW)
+    set(${return_url} ${input_url} PARENT_SCOPE)
+    return()
+  endif()
+
   if(${input_url} MATCHES "^[.][.][/]")
 
     cmake_path(APPEND PROJECT_SOURCE_DIR .git OUTPUT_VARIABLE git_path)
     if(EXISTS ${git_path})
       get_git_remote_url(remote_url)
       set(remote_url_prefix "${remote_url}")
+      set(matched_char)
       while(${input_url} MATCHES "^[.][.][/]")
-        string(FIND "${remote_url_prefix}" "/" truncate_point REVERSE)
+
+        # find first occurrence of / and : starting from end of url
+        string(FIND "${remote_url_prefix}" "/" slash_truncate_point REVERSE)
+        string(FIND "${remote_url_prefix}" ":" colon_truncate_point REVERSE)
+
+        if (colon_truncate_point EQUAL -1 AND slash_truncate_point EQUAL -1) 
+          message(STATUS "shacl-FetchContent_Declare - relative url ${input_url} has too many indirections for remote URL ${remote_url}")
+        endif()
+
+        # Determine the earliest position - also handles the case where one is not found
+        if(colon_truncate_point GREATER slash_truncate_point)
+            set(matched_char ":")
+            set(truncate_point ${colon_truncate_point})
+        else()
+            set(matched_char "/")
+            set(truncate_point ${slash_truncate_point})
+        endif()
+
         string(SUBSTRING "${remote_url_prefix}" 0 ${truncate_point} remote_url_prefix)
         string(SUBSTRING "${input_url}" 3 -1 input_url)
       endwhile()
-      set(retval "${remote_url_prefix}/${input_url}")
+      set(retval "${remote_url_prefix}${matched_char}${input_url}")
     else()
       message(STATUS "shacl-FetchContent_Declare - relative url ${input_url} provided but ${PROJECT_NAME} isn't a git repository.")
       set(retval "${input_url}")


### PR DESCRIPTION
* fixes bug for paths containing colons
* circumvents custom relative URL handling when CMake >= 3.27
* adds option to force use of find_package